### PR TITLE
Default file system and additional customize features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.13...3.27)
 option(WITHOUT_BLOCKDEVICE_SD "without SD block device in demo and tests")
 
 include(vendor/pico_sdk_import.cmake)
+include(pico_vfs.cmake)
 set(FAMILY rp2040)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
@@ -68,9 +69,26 @@ target_include_directories(filesystem_vfs INTERFACE
 )
 target_compile_options(filesystem_vfs INTERFACE -Werror -Wall -Wextra -Wnull-dereference)
 
+# Default file system library
+add_library(filesystem_default INTERFACE)
+target_sources(filesystem_default INTERFACE src/filesystem/fs_init.c)
+target_include_directories(filesystem_default INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/include
+)
+target_compile_options(filesystem_default INTERFACE -Werror -Wall -Wextra -Wnull-dereference)
+target_link_libraries(filesystem_default INTERFACE
+  blockdevice_flash
+  filesystem_littlefs
+  filesystem_vfs
+)
+
+
 add_subdirectory(examples/benchmark EXCLUDE_FROM_ALL)
 add_subdirectory(examples/usb_msc_logger EXCLUDE_FROM_ALL)
+add_subdirectory(examples/default_fs EXCLUDE_FROM_ALL)
+
 add_subdirectory(tests EXCLUDE_FROM_ALL)
+
 
 find_program(OPENOCD openocd)
 if(OPENOCD)

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -25,6 +25,12 @@ make benchmark
 make logger
 ```
 
+## Default file system
+
+The default file system can be enabled in `CMakeLists.txt`. Don't forget to include `pico_vfs.cmake` beforehand. Of course, you can easily add your own file system initialisation code.
+
+[examples/default\_fs](examples/default_fs/)
+
 ## Unit and Integration test code
 
 The attached test code includes unit tests for each of the block device API, file system API and VFS API, as well as integration test code to copy data between different block devices and different file systems.

--- a/examples/default_fs/CMakeLists.txt
+++ b/examples/default_fs/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Default filesystem init demo
+add_executable(default_fs main.c)
+target_link_libraries(default_fs PRIVATE pico_stdlib)
+pico_enable_stdio_usb(default_fs 1)
+pico_add_extra_outputs(default_fs)
+
+# use default file system
+#pico_enable_filesystem(default_fs FS_SIZE 524288)
+
+pico_enable_filesystem(default_fs FS_INIT my_fs_init.c)
+target_link_libraries(default_fs PRIVATE
+  pico_stdlib
+  blockdevice_flash
+  blockdevice_sd
+  filesystem_littlefs
+  filesystem_fat
+  filesystem_vfs
+)
+
+# Additional sources of initialisation functions can be added to customise the file system configuration.
+#
+# pico_enable_filesystem(default_fs FS_INIT my_fs_init.c)
+# target_link_libraries(default_fs PRIVATE
+#   pico_stdlib
+#   blockdevice_flash
+#   blockdevice_sd
+#   filesystem_littlefs
+#   filesystem_fat
+#   filesystem_vfs
+# )
+
+
+find_program(OPENOCD openocd)
+if(OPENOCD)
+  add_custom_target(run_default_fs
+    COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program default_fs.elf verify reset exit"
+    DEPENDS default_fs
+  )
+endif()

--- a/examples/default_fs/main.c
+++ b/examples/default_fs/main.c
@@ -1,0 +1,19 @@
+#include <pico/stdlib.h>
+#include <stdio.h>
+#include "filesystem/vfs.h"
+
+
+int main(void) {
+    stdio_init_all();
+    fs_init();
+
+    int fd = fs_open("/HELLO.TXT", O_WRONLY|O_CREAT);
+    if (fd < 0)
+        printf("fs_open error error=%d\n", fd);
+    int err = fs_write(fd, "Hello World!\n", 12);
+    if (err < 0)
+        printf("fs_write error=%d\n", err);
+    err = fs_close(fd);
+    if (err != 0)
+        printf("fs_close error=%d\n", err);
+}

--- a/examples/default_fs/my_fs_init.c
+++ b/examples/default_fs/my_fs_init.c
@@ -1,0 +1,32 @@
+#include <hardware/clocks.h>
+#include <hardware/flash.h>
+#include "blockdevice/flash.h"
+#include "blockdevice/sd.h"
+#include "filesystem/fat.h"
+#include "filesystem/littlefs.h"
+#include "filesystem/vfs.h"
+
+
+bool fs_init(void) {
+    printf("create On-board flash block device\n");
+    blockdevice_t *flash = blockdevice_flash_create(PICO_FLASH_SIZE_BYTES - DEFAULT_FS_SIZE, 0);
+    printf("create littlefs file system\n");
+    filesystem_t *lfs = filesystem_littlefs_create(500, 16);
+    printf("mount /\n");
+    fs_mount("/", lfs, flash);
+
+    printf("create SD block device\n");
+    blockdevice_t *sd = blockdevice_sd_create(spi0,
+                                              PICO_DEFAULT_SPI_TX_PIN,
+                                              PICO_DEFAULT_SPI_RX_PIN,
+                                              PICO_DEFAULT_SPI_SCK_PIN,
+                                              PICO_DEFAULT_SPI_CSN_PIN,
+                                              24 * MHZ,
+                                              false);
+    printf("create FAT file system\n");
+    filesystem_t *fat = filesystem_fat_create();
+    printf("mount /sd\n");
+    fs_mount("/sd", fat, sd);
+
+    return true;
+}

--- a/include/filesystem/vfs.h
+++ b/include/filesystem/vfs.h
@@ -13,6 +13,13 @@ extern "C" {
 #include "filesystem/filesystem.h"
 #include "blockdevice/blockdevice.h"
 
+
+#if !defined(DEFAULT_FS_SIZE)
+#define DEFAULT_FS_SIZE    (512 * 1024)
+#endif
+
+bool fs_init(void);
+
 /** Format block device with specify file system
  *
  * Block devices can be formatted and made available as a file system.

--- a/pico_vfs.cmake
+++ b/pico_vfs.cmake
@@ -1,0 +1,20 @@
+# For enable default file system
+
+set(PICO_VFS_PATH "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "PICO VFS directory")
+
+function(pico_enable_filesystem TARGET)
+  set(options "")
+  set(oneValueArgs SIZE)
+  set(multiValueArgs FS_INIT)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(ARG_SIZE)
+    target_compile_definitions(${TARGET} PRIVATE DEFAULT_FS_SIZE=${ARG_SIZE})
+  endif()
+
+  if(ARG_FS_INIT)
+    target_sources(${TARGET} PRIVATE ${ARG_FS_INIT})
+  else()
+    target_link_libraries(${TARGET} PRIVATE filesystem_default)
+  endif()
+endfunction()

--- a/src/filesystem/fs_init.c
+++ b/src/filesystem/fs_init.c
@@ -1,0 +1,20 @@
+#include <hardware/flash.h>
+#include "blockdevice/flash.h"
+#include "filesystem/littlefs.h"
+#include "filesystem/vfs.h"
+
+
+bool __attribute__((weak)) fs_init(void) {
+    filesystem_t *fs = filesystem_littlefs_create(500, 16);
+    blockdevice_t *device = blockdevice_flash_create(PICO_FLASH_SIZE_BYTES - DEFAULT_FS_SIZE, 0);
+
+    int err = fs_mount("/", fs, device) == 0;
+    if (err != 0) {
+        err = fs->format(fs, device);
+        if (err != 0) {
+            return false;
+        }
+        err = fs_mount("/", fs, device);
+    }
+    return err == 0;
+}


### PR DESCRIPTION
Specify the following function in the project's CMakeLists.txt to add a default file system:

```CMakeLists.txt
pico_enable_filesystem(${CMAKE_PROJECT_NAME})
```

The default file system is available from the code by executing `fs_init();`:

```c
#include <pico/stdlib.h>
#include <stdio.h>
#include "filesystem/vfs.h"

int main(void) {
    fs_init();

    int fd = fs_open("/HELLO.TXT", O_WRONLY|O_CREAT);
    fs_write(fd, "Hello World!\n", 12);
    fs_close(fd);
}
```

The default file system is the 512 KB of Pico's on-board flash mounted with littlefs. The `pico_enable_filesystem` function allows the size of the default file system to be specified in the argument:
```CMakeLists.txt
pico_enable_filesystem(${CMAKE_PROJECT_NAME} FS_SIZE  524288)
```

It can also specify the initialisation code for a custom filesystem:
```CMakeLists.txt
pico_enable_filesystem(${CMAKE_PROJECT_NAME} FS_INIT my_fs_init.c)
```