### PR TITLE
Automatic fs_init() call feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ By default, 1.4MB of littlefs is mounted at `/`, and the Pico's onboard flash me
 If you want to customize the storage size, specify the required storage size in `pico_enable_filesystem`:
 
 ```CMakeLists.txt
-pico_enable_filesystem(${CMAKE_PROJECT_NAME} FS_SIZE 1048576)
+pico_enable_filesystem(${CMAKE_PROJECT_NAME} FS_SIZE 1441792)
 ```
 pico-vfs can be further customized. The sample program included in [examples/default\_fs/my\_fs\_init.c](examples/default_fs/my_fs_init.c) demonstrates mounting a FAT file system using an SD card as a block device and littlefs on the onboard flash memory in a single namespace.
 

--- a/examples/default_fs/CMakeLists.txt
+++ b/examples/default_fs/CMakeLists.txt
@@ -4,8 +4,8 @@ target_link_libraries(default_fs PRIVATE pico_stdlib)
 pico_enable_stdio_usb(default_fs 1)
 pico_add_extra_outputs(default_fs)
 
-# use default file system
-pico_enable_filesystem(default_fs FS_SIZE 524288)
+# enable file system
+pico_enable_filesystem(default_fs)
 
 # Additional sources of initialisation functions can be added to customise the file system configuration.
 #

--- a/examples/default_fs/main.c
+++ b/examples/default_fs/main.c
@@ -1,7 +1,3 @@
-/*
- * NOTE: The default file system consumes 1.4 MB (0x160000 bytes) of flash memory.
- *       This means that it can share storage with MicroPython for RP2.
- */
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>

--- a/include/filesystem/vfs.h
+++ b/include/filesystem/vfs.h
@@ -14,8 +14,8 @@ extern "C" {
 #include "blockdevice/blockdevice.h"
 
 
-#if !defined(DEFAULT_FS_SIZE)
-#define DEFAULT_FS_SIZE    (1408 * 1024)   // Can share storage with MicroPython for RP2
+#if !defined(PICO_FS_DEFAULT_SIZE)
+#define PICO_FS_DEFAULT_SIZE         (1408 * 1024)   // Can share storage with MicroPython for RP2
 #endif
 
 /** Enable predefined file systems

--- a/pico_vfs.cmake
+++ b/pico_vfs.cmake
@@ -3,18 +3,24 @@
 set(PICO_VFS_PATH "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "PICO VFS directory")
 
 function(pico_enable_filesystem TARGET)
+
   set(options "")
-  set(oneValueArgs SIZE)
+  set(oneValueArgs SIZE AUTO_INIT)
   set(multiValueArgs FS_INIT)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+
   if(ARG_SIZE)
-    target_compile_definitions(${TARGET} PRIVATE DEFAULT_FS_SIZE=${ARG_SIZE})
+    target_compile_definitions(${TARGET} PRIVATE PICO_FS_DEFAULT_SIZE=${ARG_SIZE})
   endif()
 
   if(ARG_FS_INIT)
     target_sources(${TARGET} PRIVATE ${ARG_FS_INIT})
   else()
     target_link_libraries(${TARGET} PRIVATE filesystem_default)
+  endif()
+
+  if(ARG_AUTO_INIT)
+    target_compile_definitions(${TARGET} PRIVATE PICO_FS_AUTO_INIT=1)
   endif()
 endfunction()

--- a/src/filesystem/fs_init.c
+++ b/src/filesystem/fs_init.c
@@ -6,7 +6,7 @@
 
 bool __attribute__((weak)) fs_init(void) {
     filesystem_t *fs = filesystem_littlefs_create(500, 16);
-    blockdevice_t *device = blockdevice_flash_create(PICO_FLASH_SIZE_BYTES - DEFAULT_FS_SIZE, 0);
+    blockdevice_t *device = blockdevice_flash_create(PICO_FLASH_SIZE_BYTES - PICO_FS_DEFAULT_SIZE, 0);
 
     int err = fs_mount("/", fs, device);
     if (err == -1) {

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -65,7 +65,6 @@ static mountpoint_t *find_mountpoint(const char *path) {
     return longest_match;
 }
 
-
 int fs_format(filesystem_t *fs, blockdevice_t *device) {
     return fs->format(fs, device);
 }
@@ -320,3 +319,9 @@ struct dirent *readdir(DIR *dir) {
 char *fs_strerror(int error) {
     return strerror(-error);
 }
+
+#if defined(PICO_FS_AUTO_INIT)
+void __attribute__((constructor)) pre_main(void) {
+    fs_init();
+}
+#endif


### PR DESCRIPTION
Added option to add `fs_init()` to `pre_main()`.
Enabled by the following CMake function options.
```CMakeLists.txt
pico_enable_filesystem(${CMAKE_PROJECT_NAME} AUTO_INIT TRUE)
```