### PR TITLE
Add multi-core file IO tests

### DIFF
--- a/src/blockdevice/flash.c
+++ b/src/blockdevice/flash.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include "blockdevice/flash.h"
 
-
 typedef struct {
     uint32_t start;
     size_t length;
@@ -42,35 +41,36 @@ static int sync(blockdevice_t *device) {
 
 static int read(blockdevice_t *device, const void *buffer, size_t addr, size_t size) {
     blockdevice_flash_config_t *config = device->config;
-    mutex_enter_blocking(&config->_mutex);
 
+    mutex_enter_blocking(&config->_mutex);
     const uint8_t *flash_contents = (const uint8_t *)(XIP_BASE + flash_target_offset(device) + addr);
     memcpy((uint8_t *)buffer, flash_contents, size);
     mutex_exit(&config->_mutex);
+
     return BD_ERROR_OK;
 }
 
 static int erase(blockdevice_t *device, size_t addr, size_t size) {
     blockdevice_flash_config_t *config = device->config;
-    mutex_enter_blocking(&config->_mutex);
 
+    mutex_enter_blocking(&config->_mutex);
     uint32_t ints = save_and_disable_interrupts();
     flash_range_erase(flash_target_offset(device) + addr, size);
     restore_interrupts(ints);
-
     mutex_exit(&config->_mutex);
+
     return BD_ERROR_OK;
 }
 
 static int program(blockdevice_t *device, const void *buffer, size_t addr, size_t size) {
     blockdevice_flash_config_t *config = device->config;
-    mutex_enter_blocking(&config->_mutex);
 
+    mutex_enter_blocking(&config->_mutex);
     uint32_t ints = save_and_disable_interrupts();
     flash_range_program(flash_target_offset(device) + addr, buffer, size);
     restore_interrupts(ints);
-
     mutex_exit(&config->_mutex);
+
     return BD_ERROR_OK;
 }
 

--- a/src/filesystem/littlefs.c
+++ b/src/filesystem/littlefs.c
@@ -21,7 +21,6 @@ typedef struct {
     mutex_t _mutex;
 } filesystem_littlefs_context_t;
 
-
 static const char FILESYSTEM_NAME[] = "littlefs";
 
 static int _error_remap(int err) {

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -107,7 +107,7 @@ int fs_mount(const char *dir, filesystem_t *fs, blockdevice_t *device) {
     }
 
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
     for (size_t i = 0; i < FS_MAX_MOUNTPOINT; i++) {
         if (mountpoints[i].filesystem == NULL) {
             mountpoints[i].filesystem = fs;
@@ -123,7 +123,7 @@ int fs_mount(const char *dir, filesystem_t *fs, blockdevice_t *device) {
 
 int fs_unmount(const char *path) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -147,7 +147,7 @@ int fs_unmount(const char *path) {
 
 int fs_reformat(const char *path) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -178,7 +178,7 @@ int fs_info(const char *path, filesystem_t **fs, blockdevice_t **device) {
     (void)device;
 
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -194,7 +194,7 @@ int fs_info(const char *path, filesystem_t **fs, blockdevice_t **device) {
 
 int _unlink(const char *path) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -211,7 +211,7 @@ int _unlink(const char *path) {
 int rename(const char *old, const char *new) {
     // TODO: Check if old and new are the same filesystem
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
     mountpoint_t *mp = find_mountpoint(old);
     if (mp == NULL) {
         recursive_mutex_exit(&_mutex);
@@ -228,7 +228,7 @@ int rename(const char *old, const char *new) {
 
 int mkdir(const char *path, mode_t mode) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
         recursive_mutex_exit(&_mutex);
@@ -243,7 +243,7 @@ int mkdir(const char *path, mode_t mode) {
 
 int rmdir(const char *path) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
         recursive_mutex_exit(&_mutex);
@@ -258,7 +258,7 @@ int rmdir(const char *path) {
 
 int _stat(const char *path, struct stat *st) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
         recursive_mutex_exit(&_mutex);
@@ -273,7 +273,7 @@ int _stat(const char *path, struct stat *st) {
 
 int _fstat(int fildes, struct stat *st) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (fildes == STDIN_FILENO || fildes == STDOUT_FILENO || fildes == STDERR_FILENO) {
         recursive_mutex_exit(&_mutex);
@@ -403,7 +403,7 @@ static int _assign_dir_descriptor(void) {
 
 int _open(const char *path, int oflags, ...) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -442,7 +442,7 @@ int _open(const char *path, int oflags, ...) {
 
 int _close(int fildes) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (!is_valid_file_descriptor(fildes)) {
         printf("_close error fildes=%d\n", fildes);
@@ -490,7 +490,7 @@ static size_t pico_stdio_fallback_read(void *buf, size_t nbyte) {
 
 ssize_t _write(int fildes, const void *buf, size_t nbyte) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (fildes == STDOUT_FILENO || fildes == STDERR_FILENO) {
         pico_stdio_fallback_write(buf, nbyte);
@@ -508,13 +508,14 @@ ssize_t _write(int fildes, const void *buf, size_t nbyte) {
         return _error_remap(-EBADF);
     }
     ssize_t size = fs->file_write(fs, file, buf, nbyte);
+
     recursive_mutex_exit(&_mutex);
     return _error_remap(size);
 }
 
 ssize_t _read(int fildes, void *buf, size_t nbyte) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (fildes == STDIN_FILENO) {
         size_t read_bytes = pico_stdio_fallback_read(buf, nbyte);
@@ -540,7 +541,7 @@ ssize_t _read(int fildes, void *buf, size_t nbyte) {
 
 off_t _lseek(int fildes, off_t offset, int whence) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (!is_valid_file_descriptor(fildes)) {
         recursive_mutex_exit(&_mutex);
@@ -563,7 +564,7 @@ off_t _ftello_r(struct _reent *ptr, register FILE *fp) {
     (void)ptr;
     int fildes = fp->_file;
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (!is_valid_file_descriptor(fildes)) {
         recursive_mutex_exit(&_mutex);
@@ -584,7 +585,7 @@ off_t _ftello_r(struct _reent *ptr, register FILE *fp) {
 
 int ftruncate(int fildes, off_t length) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     if (!is_valid_file_descriptor(fildes)) {
         recursive_mutex_exit(&_mutex);
@@ -605,7 +606,7 @@ int ftruncate(int fildes, off_t length) {
 
 DIR *opendir(const char *path) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     mountpoint_t *mp = find_mountpoint(path);
     if (mp == NULL) {
@@ -646,7 +647,7 @@ DIR *opendir(const char *path) {
 
 int closedir(DIR *dir) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     int fd = dir->fd;
     fs_dir_t *_dir = dir_descriptor[dir->fd].dir;
@@ -665,7 +666,7 @@ int closedir(DIR *dir) {
 
 struct dirent *readdir(DIR *dir) {
     auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking (&_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
 
     fs_dir_t *_dir = dir_descriptor[dir->fd].dir;
     filesystem_t *fs = dir_descriptor[dir->fd].filesystem;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,15 +23,39 @@ target_link_libraries(tests PRIVATE
   filesystem_vfs
 )
 target_link_options(tests PRIVATE -Wl,--print-memory-usage)
-
 pico_add_extra_outputs(tests)
 pico_enable_stdio_usb(tests 1)
 
+
+add_executable(multicore multicore.c)
+if(WITHOUT_BLOCKDEVICE_SD)
+  target_compile_definitions(multicore PRIVATE WITHOUT_BLOCKDEVICE_SD=1)
+endif()
+target_compile_options(multicore PRIVATE -Werror -Wall -Wextra -Wnull-dereference)
+target_link_libraries(multicore PRIVATE
+  pico_stdlib
+  pico_multicore
+  blockdevice_flash
+  blockdevice_heap
+  blockdevice_sd
+  filesystem_fat
+  filesystem_littlefs
+  filesystem_vfs
+)
+target_link_options(multicore PRIVATE -Wl,--print-memory-usage)
+pico_add_extra_outputs(multicore)
+pico_enable_stdio_uart(multicore 1)
+pico_enable_stdio_usb(multicore 0)
+pico_set_binary_type(multicore copy_to_ram)
 
 find_program(OPENOCD openocd)
 if(OPENOCD)
   add_custom_target(run_tests
     COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program tests.elf verify reset exit"
     DEPENDS tests
+  )
+  add_custom_target(run_multicore
+    COMMAND ${OPENOCD} -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000" -c "program multicore.elf verify reset exit"
+    DEPENDS multicore
   )
 endif()

--- a/tests/main.c
+++ b/tests/main.c
@@ -3,10 +3,10 @@
 
 #define COLOR_GREEN(format)  ("\e[32m" format "\e[0m")
 
-extern void test_blockdevice();
-extern void test_filesystem();
-extern void test_vfs();
-extern void test_stdio();
+extern void test_blockdevice(void);
+extern void test_filesystem(void);
+extern void test_vfs(void);
+extern void test_stdio(void);
 extern void test_copy_between_different_filesystems(void);
 
 int main(void) {
@@ -21,4 +21,6 @@ int main(void) {
     test_copy_between_different_filesystems();
 
     printf(COLOR_GREEN("All tests are ok\n"));
+    while (1)
+        tight_loop_contents();
 }

--- a/tests/multicore.c
+++ b/tests/multicore.c
@@ -1,0 +1,313 @@
+#include <assert.h>
+#include <hardware/clocks.h>
+#include <hardware/flash.h>
+#include <pico/multicore.h>
+#include <pico/stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "blockdevice/flash.h"
+#include "blockdevice/heap.h"
+#include "blockdevice/sd.h"
+#include "filesystem/littlefs.h"
+#include "filesystem/fat.h"
+#include "filesystem/vfs.h"
+
+#define COLOR_GREEN(format)  ("\e[32m" format "\e[0m")
+
+#define TEST_FILE_SIZE      32 * 1024;
+#define FLASH_START_AT      (0.5 * 1024 * 1024)
+#define FLASH_LENGTH_ALL    0
+
+
+struct combination_map {
+    blockdevice_t *device;
+    filesystem_t *filesystem;
+    const char *label;
+};
+
+#if defined(WITHOUT_BLOCKDEVICE_SD)
+#define NUM_COMBINATION    2
+#else
+#define NUM_COMBINATION    4
+#endif
+
+
+static struct combination_map combination[NUM_COMBINATION];
+
+static void init_filesystem_combination(void) {
+    blockdevice_t *flash = blockdevice_flash_create(PICO_FLASH_SIZE_BYTES - PICO_FS_DEFAULT_SIZE,
+                                                    FLASH_LENGTH_ALL);
+#if !defined(WITHOUT_BLOCKDEVICE_SD)
+    blockdevice_t *sd = blockdevice_sd_create(spi0,
+                                              PICO_DEFAULT_SPI_TX_PIN,
+                                              PICO_DEFAULT_SPI_RX_PIN,
+                                              PICO_DEFAULT_SPI_SCK_PIN,
+                                              PICO_DEFAULT_SPI_CSN_PIN,
+                                              10 * MHZ,
+                                              true);
+#endif
+    filesystem_t *fat = filesystem_fat_create();
+    filesystem_t *littlefs = filesystem_littlefs_create(500, 16);
+
+    combination[0] = (struct combination_map){
+        .device = flash, .filesystem = littlefs, .label = "littlefs on Flash"
+    };
+    combination[1] = (struct combination_map){
+        .device = flash, .filesystem = fat, .label = "FAT on Flash"
+    };
+#if !defined(WITHOUT_BLOCKDEVICE_SD)
+    combination[2] = (struct combination_map){
+        .device = sd, .filesystem = littlefs, .label = "littlefs on SD card"
+    };
+    combination[3] = (struct combination_map){
+        .device = sd, .filesystem = fat, .label = "FAT on SD card"
+    };
+#endif
+}
+
+static void cleanup_combination(void) {
+    filesystem_littlefs_free(combination[0].filesystem);
+    filesystem_fat_free(combination[1].filesystem);
+    blockdevice_flash_free(combination[0].device);
+#if !defined(WITHOUT_BLOCKDEVICE_SD)
+    blockdevice_sd_free(combination[2].device);
+#endif
+}
+
+static void test_printf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int n = vprintf(format, args);
+    va_end(args);
+
+    printf(" ");
+    for (size_t i = 0; i < 50 - (size_t)n; i++)
+        printf(".");
+}
+
+static void __not_in_flash_func(test_write_read_two_files_core1)(void) {
+    int fd = open("/core1", O_WRONLY|O_CREAT);
+
+    uint8_t buffer[512] = {0};
+    size_t remind = TEST_FILE_SIZE;
+    unsigned seed = 1;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        for (size_t i = 0; i < (size_t)chunk; i++) {
+            buffer[i] = rand_r(&seed) & 0xFF;
+        }
+        ssize_t write_size = write(fd, buffer, chunk);
+        assert(write_size != -1);
+        remind = remind - write_size;
+    }
+    int err = close(fd);
+    assert(err == 0);
+
+    fd = open("/core1", O_RDONLY);
+    assert(fd != 0);
+
+    seed = 1;
+    remind = TEST_FILE_SIZE;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        ssize_t read_size = read(fd, buffer, chunk);
+        assert(read_size != -1);
+        for (size_t i = 0; i < (size_t)read_size; i++) {
+            volatile uint8_t r = rand_r(&seed) & 0xFF;
+            assert(buffer[i] == r);
+        }
+        remind = remind - read_size;
+    }
+
+    err = close(fd);
+    assert(err == 0);
+
+    multicore_fifo_push_blocking(1); // finish
+    while (1)
+        tight_loop_contents();
+
+}
+
+static void test_write_read_two_files(void) {
+    test_printf("Write then read");
+
+    multicore_reset_core1();
+    multicore_launch_core1(test_write_read_two_files_core1);
+
+    int fd = open("/core0", O_WRONLY|O_CREAT);
+    uint8_t buffer[512] = {0};
+    size_t remind = TEST_FILE_SIZE;
+    unsigned seed = 0;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        for (size_t i = 0; i < (size_t)chunk; i++) {
+            buffer[i] = rand_r(&seed) & 0xFF;
+        }
+        ssize_t write_size = write(fd, buffer, chunk);
+        assert(write_size != -1);
+        remind = remind - write_size;
+    }
+
+    int err = close(fd);
+    assert(err == 0);
+
+    fd = open("/core0", O_RDONLY);
+    assert(fd != 0);
+
+    seed = 0;
+    remind = TEST_FILE_SIZE;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        ssize_t read_size = read(fd, buffer, chunk);
+        assert(read_size != -1);
+
+        for (size_t i = 0; i < (size_t)read_size; i++) {
+            volatile uint8_t r = rand_r(&seed) & 0xFF;
+            assert(buffer[i] == r);
+        }
+        remind = remind - read_size;
+    }
+    err = close(fd);
+    assert(err == 0);
+
+    uint32_t result = multicore_fifo_pop_blocking();
+    assert(result == 1);
+
+    printf(COLOR_GREEN("ok\n"));
+}
+
+
+static void __not_in_flash_func(test_write_while_read_two_files_core1)(void) {
+    int fd = open("/core1", O_WRONLY|O_CREAT);
+
+    uint8_t buffer[512] = {0};
+    size_t remind = TEST_FILE_SIZE;
+    unsigned seed = 1;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        for (size_t i = 0; i < (size_t)chunk; i++) {
+            buffer[i] = rand_r(&seed) & 0xFF;
+        }
+        ssize_t write_size = write(fd, buffer, chunk);
+        assert(write_size != -1);
+        remind = remind - write_size;
+    }
+    int err = close(fd);
+    assert(err == 0);
+    multicore_fifo_push_blocking(1); // write finish
+
+    fd = open("/core1", O_RDONLY);
+    assert(fd != 0);
+    seed = 1;
+    remind = TEST_FILE_SIZE;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        ssize_t read_size = read(fd, buffer, chunk);
+        assert(read_size != -1);
+        for (size_t i = 0; i < (size_t)read_size; i++) {
+            volatile uint8_t r = rand_r(&seed) & 0xFF;
+            assert(buffer[i] == r);
+        }
+        remind = remind - read_size;
+    }
+    err = close(fd);
+    assert(err == 0);
+
+    multicore_fifo_push_blocking(1); // read finish
+    while (1)
+        tight_loop_contents();
+
+}
+
+
+static void test_write_while_read_two_files(void) {
+    test_printf("Write while read");
+
+    multicore_reset_core1();
+    multicore_launch_core1(test_write_while_read_two_files_core1);
+
+    int fd = open("/core0", O_RDONLY);
+    assert(fd != 0);
+    uint8_t buffer[512] = {0};
+
+    unsigned seed = 0;
+    size_t remind = TEST_FILE_SIZE;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        ssize_t read_size = read(fd, buffer, chunk);
+        assert(read_size != -1);
+
+        for (size_t i = 0; i < (size_t)read_size; i++) {
+            volatile uint8_t r = rand_r(&seed) & 0xFF;
+            assert(buffer[i] == r);
+        }
+        remind = remind - read_size;
+    }
+    int err = close(fd);
+    assert(err == 0);
+
+    // wait core1
+    uint32_t result = multicore_fifo_pop_blocking();
+    assert(result == 1);
+
+    fd = open("/core0", O_WRONLY|O_CREAT);
+    remind = TEST_FILE_SIZE;
+    seed = 0;
+    while (remind > 0) {
+        size_t chunk = remind % sizeof(buffer) ? remind % sizeof(buffer) : sizeof(buffer);
+        for (size_t i = 0; i < (size_t)chunk; i++) {
+            buffer[i] = rand_r(&seed) & 0xFF;
+        }
+        ssize_t write_size = write(fd, buffer, chunk);
+        assert(write_size != -1);
+        remind = remind - write_size;
+    }
+    err = close(fd);
+    assert(err == 0);
+
+    // wait core1
+    result = multicore_fifo_pop_blocking();
+    assert(result == 1);
+
+    printf(COLOR_GREEN("ok\n"));
+}
+
+
+static void setup(filesystem_t *fs, blockdevice_t *device) {
+    int err = fs_format(fs, device);
+    assert(err == 0);
+    err = fs_mount("/", fs, device);
+    assert(err == 0);
+}
+
+static void cleanup() {
+    int err = fs_reformat("/");
+    assert(err == 0);
+    err = fs_unmount("/");
+    assert(err == 0);
+}
+
+int main(void) {
+    stdio_init_all();
+    printf("Start multicore tests\n");
+
+    init_filesystem_combination();
+    for (size_t i = 0; i < NUM_COMBINATION; i++) {
+        struct combination_map setting = combination[i];
+        printf("%s:\n", setting.label);
+
+        setup(setting.filesystem, setting.device);
+
+        test_write_read_two_files();
+        test_write_while_read_two_files();
+
+        cleanup();
+    }
+    cleanup_combination();
+
+    printf(COLOR_GREEN("All tests are ok\n"));
+    while (1)
+        tight_loop_contents();
+}


### PR DESCRIPTION
Fix #29

Add tests using Flash and SD block devices and a combination of littlefs and FAT to use the file system in both core0/core1 at the same time.
Note that only Flash block devices require the functions to be executed in core1 to be in RAM.