### PR TITLE
Remap O_APPEND to f_open in FatFs

### DIFF
--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -412,13 +412,14 @@ static int file_open(filesystem_t *fs, fs_file_t *file, const char *path, int fl
         open_mode = FA_WRITE;
     else
         open_mode = FA_READ;
-
     if (flags & O_CREAT) {
         if (flags & O_TRUNC)
             open_mode |= FA_CREATE_ALWAYS;
         else
             open_mode |= FA_OPEN_ALWAYS;
     }
+    if (flags & O_APPEND)
+        open_mode |= FA_OPEN_APPEND;
 
     char fpath[PATH_MAX];
     filesystem_fat_context_t *context = fs->context;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(unittests
   test_blockdevice.c
   test_filesystem.c
   test_vfs.c
-  test_stdio.c
+  test_standard.c
   test_copy_between_different_filesystems.c
 )
 target_compile_options(unittests PRIVATE -Werror -Wall -Wextra -Wnull-dereference)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(integration
   test_blockdevice.c
   test_filesystem.c
   test_vfs.c
-  test_stdio.c
+  test_standard.c
   test_copy_between_different_filesystems.c
 )
 target_compile_options(integration PRIVATE -Werror -Wall -Wextra -Wnull-dereference)

--- a/tests/integration/main.c
+++ b/tests/integration/main.c
@@ -6,7 +6,7 @@
 extern void test_blockdevice(void);
 extern void test_filesystem(void);
 extern void test_vfs(void);
-extern void test_stdio(void);
+extern void test_standard(void);
 extern void test_copy_between_different_filesystems(void);
 
 int main(void) {
@@ -17,7 +17,7 @@ int main(void) {
     test_blockdevice();
     test_filesystem();
     test_vfs();
-    test_stdio();
+    test_standard();
     test_copy_between_different_filesystems();
 
     printf(COLOR_GREEN("All tests are ok\n"));

--- a/tests/integration/test_standard.c
+++ b/tests/integration/test_standard.c
@@ -4,13 +4,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <wchar.h>
-#include "blockdevice/heap.h"
+#include "blockdevice/flash.h"
 #include "filesystem/fat.h"
 #include "filesystem/littlefs.h"
 #include "filesystem/vfs.h"
 
 #define COLOR_GREEN(format)      ("\e[32m" format "\e[0m")
-#define HEAP_STORAGE_SIZE        (128 * 1024)
+#define FLASH_START_AT           (0.5 * 1024 * 1024)
+#define FLASH_LENGTH_ALL         0
 #define LITTLEFS_BLOCK_CYCLE     500
 #define LITTLEFS_LOOKAHEAD_SIZE  16
 
@@ -976,32 +977,31 @@ void test_standard_file_api(void) {
     test_vfwscanf();
 }
 
-
-void test_stdio(void) {
+void test_standard(void) {
     printf("POSIX and C standard file API(littlefs):\n");
 
-    blockdevice_t *heap = blockdevice_heap_create(HEAP_STORAGE_SIZE);
+    blockdevice_t *flash = blockdevice_flash_create(FLASH_START_AT, FLASH_LENGTH_ALL);
     filesystem_t *lfs = filesystem_littlefs_create(LITTLEFS_BLOCK_CYCLE,
                                                    LITTLEFS_LOOKAHEAD_SIZE);
 
-    setup(lfs, heap);
+    setup(lfs, flash);
 
     test_standard_file_api();
 
-    cleanup(lfs, heap);
+    cleanup(lfs, flash);
     filesystem_littlefs_free(lfs);
-    blockdevice_heap_free(heap);
+    blockdevice_flash_free(flash);
 
 
     printf("POSIX and C standard file API(FAT):\n");
 
-    heap = blockdevice_heap_create(HEAP_STORAGE_SIZE);
+    flash = blockdevice_flash_create(FLASH_START_AT, FLASH_LENGTH_ALL);
     filesystem_t *fat = filesystem_fat_create();
-    setup(fat, heap);
+    setup(fat, flash);
 
     test_standard_file_api();
 
-    cleanup(fat, heap);
+    cleanup(fat, flash);
     filesystem_fat_free(fat);
-    blockdevice_heap_free(heap);
+    blockdevice_flash_free(flash);
 }

--- a/tests/main.c
+++ b/tests/main.c
@@ -6,7 +6,7 @@
 extern void test_blockdevice(void);
 extern void test_filesystem(void);
 extern void test_vfs(void);
-extern void test_stdio(void);
+extern void test_standard(void);
 extern void test_copy_between_different_filesystems(void);
 
 int main(void) {
@@ -17,7 +17,7 @@ int main(void) {
     test_blockdevice();
     test_filesystem();
     test_vfs();
-    test_stdio();
+    test_standard();
     test_copy_between_different_filesystems();
 
     printf(COLOR_GREEN("All tests are ok\n"));

--- a/tests/test_vfs.c
+++ b/tests/test_vfs.c
@@ -194,6 +194,17 @@ static void test_api_file_seek() {
     int err = close(fd);
     assert(err == 0);
 
+    fd = open("/file", O_RDWR|O_APPEND);
+    char append_buffer[] = "APPEND";
+    memset(read_buffer, 0, sizeof(read_buffer));
+    write_length = write(fd, append_buffer, strlen(append_buffer));
+    assert((size_t)write_length == strlen(append_buffer));
+    lseek(fd, 0, SEEK_SET);
+    read_length = read(fd, read_buffer, sizeof(read_buffer));
+    assert(strcmp(read_buffer, "123456789ABCDEFAPPEND") == 0);
+    err = close(fd);
+    assert(err == 0);
+
     printf(COLOR_GREEN("ok\n"));
 }
 


### PR DESCRIPTION
Fixes an issue in FatFs where `open(...) , O_APPEND)` is not passed as intended. This problem does not occur with `fopen`, only with `open`.