### PR TITLE
Fix int overflow in SDHC card capacity calculation

### DIFF
--- a/include/blockdevice/blockdevice.h
+++ b/include/blockdevice/blockdevice.h
@@ -35,7 +35,7 @@ typedef struct blockdevice {
     int (*program)(struct blockdevice *device, const void *buffer, size_t addr, size_t size);
     int (*erase)(struct blockdevice *device, size_t addr, size_t size);
     int (*trim)(struct blockdevice *device, size_t addr, size_t size);
-    size_t (*size)(struct blockdevice *device);
+    uint64_t (*size)(struct blockdevice *device);
     size_t read_size;
     size_t erase_size;
     size_t program_size;

--- a/include/filesystem/ChaN/ffconf.h
+++ b/include/filesystem/ChaN/ffconf.h
@@ -235,7 +235,7 @@
 /  buffer in the filesystem object (FATFS) is used for the file data transfer. */
 
 
-#define FF_FS_EXFAT		0
+#define FF_FS_EXFAT		1
 /* This option switches support for exFAT filesystem. (0:Disable or 1:Enable)
 /  To enable exFAT, also LFN needs to be enabled. (FF_USE_LFN >= 1)
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */

--- a/src/blockdevice/flash.c
+++ b/src/blockdevice/flash.c
@@ -83,9 +83,9 @@ static int trim(blockdevice_t *device, size_t addr, size_t size) {
     return BD_ERROR_OK;
 }
 
-static size_t size(blockdevice_t *device) {
+static uint64_t size(blockdevice_t *device) {
     blockdevice_flash_config_t *config = device->config;
-    return config->length;
+    return (uint64_t)config->length;
 }
 
 blockdevice_t *blockdevice_flash_create(uint32_t start, size_t length) {

--- a/src/blockdevice/heap.c
+++ b/src/blockdevice/heap.c
@@ -132,9 +132,9 @@ static int trim(blockdevice_t *device, size_t addr, size_t length) {
     return BD_ERROR_OK;
 }
 
-static size_t size(blockdevice_t *device) {
+static uint64_t size(blockdevice_t *device) {
     blockdevice_heap_config_t *config = device->config;
-    return config->size;
+    return (uint64_t)config->size;
 }
 
 blockdevice_t *blockdevice_heap_create(size_t length) {

--- a/src/blockdevice/loopback.c
+++ b/src/blockdevice/loopback.c
@@ -132,9 +132,9 @@ static int trim(blockdevice_t *device, size_t addr, size_t length) {
     return BD_ERROR_OK;
 }
 
-static size_t size(blockdevice_t *device) {
+static uint64_t size(blockdevice_t *device) {
     blockdevice_loopback_config_t *config = device->config;
-    return config->capacity;
+    return (uint64_t)config->capacity;
 }
 
 blockdevice_t *blockdevice_loopback_create(const char *path, size_t capacity, size_t block_size) {


### PR DESCRIPTION
Corrected a problem with int overflow and incorrect calculation when calculating the capacity of 4-32 GB SDHC cards.
Changed the return value of the size function of blockdevice from `size_t` to `uint64_t`.