### PR TITLE
Change test buffer to correct data type

### DIFF
--- a/tests/integration/test_standard.c
+++ b/tests/integration/test_standard.c
@@ -325,7 +325,7 @@ static void test_fputwc(void) {
     assert(fputwc(L'C', fp) == L'C');
 
     fseek(fp, 0, SEEK_SET);
-    wint_t buffer[512];
+    wchar_t buffer[512];
     fgetws(buffer, sizeof(buffer), fp);
     assert(wcscmp(buffer, L"WC") == 0);
 
@@ -341,7 +341,7 @@ static void test_fputws(void) {
     assert(fputws(L"WIDE CHAR\n", fp) == 0);
 
     fseek(fp, 0, SEEK_SET);
-    wint_t buffer[512];
+    wchar_t buffer[512];
     fgetws(buffer, sizeof(buffer), fp);
     assert(wcscmp(buffer, L"WIDE CHAR\n") == 0);
 
@@ -455,7 +455,7 @@ static void test_fwide(void) {
     fprintf(fp, "byte\n");
     assert(fwide(fp, 0) < 0);
 
-    fp = freopen(NULL, "w", fp);
+    fp = freopen("/fwide", "w", fp);
     assert(fwide(fp, 0) == 0);
     assert(fwide(fp, 1) > 0);
 

--- a/tests/test_standard.c
+++ b/tests/test_standard.c
@@ -337,7 +337,7 @@ static void test_fputwc(void) {
     assert(fputwc(L'C', fp) == L'C');
 
     fseek(fp, 0, SEEK_SET);
-    wint_t buffer[512];
+    wchar_t buffer[512];
     fgetws(buffer, sizeof(buffer), fp);
     assert(wcscmp(buffer, L"WC") == 0);
 
@@ -353,7 +353,7 @@ static void test_fputws(void) {
     assert(fputws(L"WIDE CHAR\n", fp) == 0);
 
     fseek(fp, 0, SEEK_SET);
-    wint_t buffer[512];
+    wchar_t buffer[512];
     fgetws(buffer, sizeof(buffer), fp);
     assert(wcscmp(buffer, L"WIDE CHAR\n") == 0);
 
@@ -467,10 +467,9 @@ static void test_fwide(void) {
     fprintf(fp, "byte\n");
     assert(fwide(fp, 0) < 0);
 
-    fp = freopen(NULL, "w", fp);
+    fp = freopen("/fwide", "w", fp);
     assert(fwide(fp, 0) == 0);
     assert(fwide(fp, 1) > 0);
-
     fclose(fp);
 
     fp = fopen("/fwide.wide", "w");


### PR DESCRIPTION
Fixed #55

- Change test buffer to correct data type `wint_t` to `wchar_t`
- Fixed test case because `freopen(NULL, ...)` does not work as expected when using RISC-V cores.