### PR TITLE
Fix errors, add fatfs modified time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ target_include_directories(filesystem_vfs INTERFACE
   ${CMAKE_CURRENT_LIST_DIR}/include
 )
 target_compile_options(filesystem_vfs INTERFACE -Werror -Wall -Wextra -Wnull-dereference)
-target_link_libraries(filesystem_vfs INTERFACE pico_sync)
+target_link_libraries(filesystem_vfs INTERFACE pico_sync -Wl,--wrap=_ftello_r)
 
 # Default file system library
 add_library(filesystem_default INTERFACE)

--- a/include/filesystem/filesystem.h
+++ b/include/filesystem/filesystem.h
@@ -19,7 +19,7 @@ extern "C" {
 #include <unistd.h>
 #include "blockdevice/blockdevice.h"
 
-#define PATH_MAX   256
+#define FS_PATH_MAX   256
 
 enum {
     FILESYSTEM_TYPE_FAT,

--- a/include/filesystem/filesystem.h
+++ b/include/filesystem/filesystem.h
@@ -17,9 +17,8 @@ extern "C" {
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <limits.h>
 #include "blockdevice/blockdevice.h"
-
-#define FS_PATH_MAX   256
 
 enum {
     FILESYSTEM_TYPE_FAT,

--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -396,8 +396,18 @@ static int file_stat(filesystem_t *fs, const char *path, struct stat *st) {
     if (res != FR_OK) {
         return fat_error_remap(res);
     }
+
+    struct tm mtime = {0};
+    mtime.tm_year = (f.fdate >> 9) + 80;
+    mtime.tm_mon = (f.fdate >> 5) & 0b1111;
+    mtime.tm_mday = f.fdate & 0b11111;
+    mtime.tm_hour = f.ftime >> 11;
+    mtime.tm_min = (f.ftime >> 5) & 0b111111;
+    mtime.tm_sec = (f.ftime & 0b11111) << 1;
+
     st->st_size = f.fsize;
     st->st_mode = 0;
+    st->st_mtime = mktime(&mtime);
     st->st_mode |= (f.fattrib & AM_DIR) ? S_IFDIR : S_IFREG;
     st->st_mode |= (f.fattrib & AM_RDO) ?
                    (S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) :

--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -399,7 +399,7 @@ static int file_stat(filesystem_t *fs, const char *path, struct stat *st) {
 
     struct tm mtime = {0};
     mtime.tm_year = (f.fdate >> 9) + 80;
-    mtime.tm_mon = (f.fdate >> 5) & 0b1111;
+    mtime.tm_mon = ((f.fdate >> 5) & 0b1111) - 1;
     mtime.tm_mday = f.fdate & 0b11111;
     mtime.tm_hour = f.ftime >> 11;
     mtime.tm_min = (f.ftime >> 5) & 0b111111;

--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -407,11 +407,11 @@ static int file_stat(filesystem_t *fs, const char *path, struct stat *st) {
 
     st->st_size = f.fsize;
     st->st_mode = 0;
-    st->st_mtime = mktime(&mtime);
     st->st_mode |= (f.fattrib & AM_DIR) ? S_IFDIR : S_IFREG;
     st->st_mode |= (f.fattrib & AM_RDO) ?
                    (S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) :
                    (S_IRWXU | S_IRWXG | S_IRWXO);
+    st->st_mtime = mktime(&mtime);
     return 0;
 }
 

--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -320,7 +320,7 @@ static const char *fat_path_prefix(char *dist, int id, const char *path) {
 static int file_remove(filesystem_t *fs, const char *path) {
     filesystem_fat_context_t *context = fs->context;
 
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -337,8 +337,8 @@ static int file_remove(filesystem_t *fs, const char *path) {
 
 static int file_rename(filesystem_t *fs, const char *oldpath, const char *newpath) {
     filesystem_fat_context_t *context = fs->context;
-    char oldfpath[PATH_MAX];
-    char newfpath[PATH_MAX];
+    char oldfpath[FS_PATH_MAX];
+    char newfpath[FS_PATH_MAX];
     fat_path_prefix(oldfpath, context->id, oldpath);
     fat_path_prefix(newfpath, context->id, newpath);
 
@@ -355,7 +355,7 @@ static int file_rename(filesystem_t *fs, const char *oldpath, const char *newpat
 static int file_mkdir(filesystem_t *fs, const char *path, mode_t mode) {
     (void)mode;
     filesystem_fat_context_t *context = fs->context;
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -370,7 +370,7 @@ static int file_mkdir(filesystem_t *fs, const char *path, mode_t mode) {
 
 static int file_rmdir(filesystem_t *fs, const char *path) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -385,7 +385,7 @@ static int file_rmdir(filesystem_t *fs, const char *path) {
 
 static int file_stat(filesystem_t *fs, const char *path, struct stat *st) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
     FILINFO f = {0};
 
@@ -422,7 +422,7 @@ static int file_open(filesystem_t *fs, fs_file_t *file, const char *path, int fl
     if (flags & O_APPEND)
         open_mode |= FA_OPEN_APPEND;
 
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     filesystem_fat_context_t *context = fs->context;
     fat_path_prefix(fpath, context->id, path);
     fat_file_t *fat_file = file->context = calloc(1, sizeof(fat_file_t));
@@ -586,7 +586,7 @@ static int file_truncate(filesystem_t *fs, fs_file_t *file, off_t length) {
 
 static int dir_open(filesystem_t *fs, fs_dir_t *dir, const char *path) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[PATH_MAX];
+    char fpath[FS_PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     FATFS_DIR *dh = calloc(1, sizeof(FATFS_DIR));

--- a/src/filesystem/fat.c
+++ b/src/filesystem/fat.c
@@ -320,7 +320,7 @@ static const char *fat_path_prefix(char *dist, int id, const char *path) {
 static int file_remove(filesystem_t *fs, const char *path) {
     filesystem_fat_context_t *context = fs->context;
 
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -337,8 +337,8 @@ static int file_remove(filesystem_t *fs, const char *path) {
 
 static int file_rename(filesystem_t *fs, const char *oldpath, const char *newpath) {
     filesystem_fat_context_t *context = fs->context;
-    char oldfpath[FS_PATH_MAX];
-    char newfpath[FS_PATH_MAX];
+    char oldfpath[PATH_MAX];
+    char newfpath[PATH_MAX];
     fat_path_prefix(oldfpath, context->id, oldpath);
     fat_path_prefix(newfpath, context->id, newpath);
 
@@ -355,7 +355,7 @@ static int file_rename(filesystem_t *fs, const char *oldpath, const char *newpat
 static int file_mkdir(filesystem_t *fs, const char *path, mode_t mode) {
     (void)mode;
     filesystem_fat_context_t *context = fs->context;
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -370,7 +370,7 @@ static int file_mkdir(filesystem_t *fs, const char *path, mode_t mode) {
 
 static int file_rmdir(filesystem_t *fs, const char *path) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     mutex_enter_blocking(&context->_mutex);
@@ -385,7 +385,7 @@ static int file_rmdir(filesystem_t *fs, const char *path) {
 
 static int file_stat(filesystem_t *fs, const char *path, struct stat *st) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
     FILINFO f = {0};
 
@@ -432,7 +432,7 @@ static int file_open(filesystem_t *fs, fs_file_t *file, const char *path, int fl
     if (flags & O_APPEND)
         open_mode |= FA_OPEN_APPEND;
 
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     filesystem_fat_context_t *context = fs->context;
     fat_path_prefix(fpath, context->id, path);
     fat_file_t *fat_file = file->context = calloc(1, sizeof(fat_file_t));
@@ -596,7 +596,7 @@ static int file_truncate(filesystem_t *fs, fs_file_t *file, off_t length) {
 
 static int dir_open(filesystem_t *fs, fs_dir_t *dir, const char *path) {
     filesystem_fat_context_t *context = fs->context;
-    char fpath[FS_PATH_MAX];
+    char fpath[PATH_MAX];
     fat_path_prefix(fpath, context->id, path);
 
     FATFS_DIR *dh = calloc(1, sizeof(FATFS_DIR));

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -562,29 +562,6 @@ off_t _lseek(int fildes, off_t offset, int whence) {
     return _error_remap(pos);
 }
 
-off_t _ftello_r(struct _reent *ptr, register FILE *fp) {
-    (void)ptr;
-    int fildes = fp->_file;
-    auto_init_recursive_mutex(_mutex);
-    recursive_mutex_enter_blocking(&_mutex);
-
-    if (!is_valid_file_descriptor(fildes)) {
-        recursive_mutex_exit(&_mutex);
-        return _error_remap(-EBADF);
-    }
-    fs_file_t *file = file_descriptor[FILENO_INDEX(fildes)].file;
-    filesystem_t *fs = file_descriptor[FILENO_INDEX(fildes)].filesystem;
-    if (fs == NULL) {
-        recursive_mutex_exit(&_mutex);
-        return _error_remap(-EBADF);
-    }
-
-    off_t pos = fs->file_tell(fs, file);
-    recursive_mutex_exit(&_mutex);
-
-    return _error_remap(pos);
-}
-
 int ftruncate(int fildes, off_t length) {
     auto_init_recursive_mutex(_mutex);
     recursive_mutex_enter_blocking(&_mutex);

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -562,6 +562,29 @@ off_t _lseek(int fildes, off_t offset, int whence) {
     return _error_remap(pos);
 }
 
+off_t __wrap__ftello_r(struct _reent *ptr, register FILE *fp) {
+    (void)ptr;
+    int fildes = fp->_file;
+    auto_init_recursive_mutex(_mutex);
+    recursive_mutex_enter_blocking(&_mutex);
+
+    if (!is_valid_file_descriptor(fildes)) {
+        recursive_mutex_exit(&_mutex);
+        return _error_remap(-EBADF);
+    }
+    fs_file_t *file = file_descriptor[FILENO_INDEX(fildes)].file;
+    filesystem_t *fs = file_descriptor[FILENO_INDEX(fildes)].filesystem;
+    if (fs == NULL) {
+        recursive_mutex_exit(&_mutex);
+        return _error_remap(-EBADF);
+    }
+
+    off_t pos = fs->file_tell(fs, file);
+    recursive_mutex_exit(&_mutex);
+
+    return _error_remap(pos);
+}
+
 int ftruncate(int fildes, off_t length) {
     auto_init_recursive_mutex(_mutex);
     recursive_mutex_enter_blocking(&_mutex);

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -21,7 +21,7 @@ typedef struct {
 typedef struct {
     fs_file_t *file;
     filesystem_t *filesystem;
-    char path[FS_PATH_MAX + 1];
+    char path[PATH_MAX + 1];
 } file_descriptor_t;
 
 typedef struct {
@@ -434,7 +434,7 @@ int _open(const char *path, int oflags, ...) {
         return _error_remap(err);
     }
     file_descriptor[FILENO_INDEX(fd)].filesystem = fs;
-    strncpy(file_descriptor[FILENO_INDEX(fd)].path, path, FS_PATH_MAX);
+    strncpy(file_descriptor[FILENO_INDEX(fd)].path, path, PATH_MAX);
 
     recursive_mutex_exit(&_mutex);
 

--- a/src/filesystem/vfs.c
+++ b/src/filesystem/vfs.c
@@ -21,7 +21,7 @@ typedef struct {
 typedef struct {
     fs_file_t *file;
     filesystem_t *filesystem;
-    char path[PATH_MAX + 1];
+    char path[FS_PATH_MAX + 1];
 } file_descriptor_t;
 
 typedef struct {
@@ -434,7 +434,7 @@ int _open(const char *path, int oflags, ...) {
         return _error_remap(err);
     }
     file_descriptor[FILENO_INDEX(fd)].filesystem = fs;
-    strncpy(file_descriptor[FILENO_INDEX(fd)].path, path, PATH_MAX);
+    strncpy(file_descriptor[FILENO_INDEX(fd)].path, path, FS_PATH_MAX);
 
     recursive_mutex_exit(&_mutex);
 


### PR DESCRIPTION
* Wrap `_ftello_r` as it collides when linking.
* Use `PATH_MAX` from limits.h instead.
* Add support for reading file modified timestamp using stat (fatfs only).

LittleFS could also support file timestamps through attributes although this would have to be implemented as an extra feature.

I'm not using pico-vfs from C directly but I made a Nim wrapper for it that I'm working on in my Pico SDK wrapper
https://github.com/daniel-j/picostdlib/blob/master/src/picostdlib/pico/filesystem.nim
https://github.com/daniel-j/picostdlib/tree/master/examples/filesystem

_ftello_r linking error:
```
/usr/lib/gcc/arm-none-eabi/14.1.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/14.1.0/../../../../arm-none-eabi/lib/thumb/v6-m/nofp/libg.a(libc_a-ftello.o): in function `_ftello_r':
/build/arm-none-eabi-newlib/src/build-newlib/arm-none-eabi/thumb/v6-m/nofp/newlib/../../../../../../newlib-4.4.0.20231231/newlib/libc/stdio/ftello.c:88: multiple definition of `_ftello_r'; CMakeFiles/test_pico.dir/picostdlib/src/picostdlib/vendor/pico-vfs/src/filesystem/vfs.c.obj (symbol from plugin):(.text+0x0): first defined here
```

Nice work on pico-vfs!